### PR TITLE
fix: catch empty comments

### DIFF
--- a/src/Support/Generators/AttributePropertyGenerator.php
+++ b/src/Support/Generators/AttributePropertyGenerator.php
@@ -64,6 +64,10 @@ class AttributePropertyGenerator implements IPropertyGenerator
         }
 
         $docComment = $method->getDocComment();
+        if (!$docComment) {
+            return 'any';
+        }
+        
         $matches = [];
         preg_match('/(?<=@return ).+/', $docComment, $matches);
 


### PR DESCRIPTION
Currently, it throws an error like this if there is no comment. This PR will catch this case and return an `any` type in that case.

```
   TypeError 

  preg_match() expects parameter 2 to be string, bool given

  at vendor/scrumble-nl/laravel-model-ts-type/src/Support/Generators/AttributePropertyGenerator.php:70
```