### PR TITLE
Change installation level to dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Generate TypeScript types based on your models.
 
 Install the package using composer:
 ```
-composer require scrumble-nl/laravel-model-ts-type
+composer require --dev scrumble-nl/laravel-model-ts-type
 ```
 ### Generating types
 ```


### PR DESCRIPTION
I don't think it is necessary to install it as a production package, since type generation only really happens in development.