### PR TITLE
Fix relation return type check

### DIFF
--- a/src/Support/Generators/RelationPropertyGenerator.php
+++ b/src/Support/Generators/RelationPropertyGenerator.php
@@ -42,7 +42,7 @@ class RelationPropertyGenerator implements IPropertyGenerator
                     continue;
                 }
 
-                $relationReturn = array_first($returnType, fn ($type) => !!strpos($type, self::RELATION_TYPE));
+                $relationReturn = array_first($returnType, fn ($type) => str_contains($type, self::RELATION_TYPE));
 
                 if ($relationReturn) {
                     $methodName = $method->getName();


### PR DESCRIPTION
The [recent release](https://github.com/scrumble-nl/laravel-model-ts-type/commit/c445302e2f3009196746fd5d9a7d33f64f68b8ce) swapped 
```php 
false !== strpos($returnType, 'Illuminate\Database\Eloquent\Relations')
```
for 
```php
$relationReturn = array_first($returnType, fn ($type) => !!strpos($type, self::RELATION_TYPE));

if ($relationReturn) {
```

which now means it will be `false` if the `self::RELATION_TYPE` is at the start of the `$type` string as the pos will be `0`.

Swapping to `str_contains` removes the need for converting the pos index to a bool.