### PR TITLE
Allow relations from intermediate parent classes

### DIFF
--- a/src/Support/Generators/RelationPropertyGenerator.php
+++ b/src/Support/Generators/RelationPropertyGenerator.php
@@ -35,7 +35,7 @@ class RelationPropertyGenerator implements IPropertyGenerator
 
         $permittedClasses = [get_class($model)];
         foreach(class_parents($model) as $parent) {
-            if ($parent == Model::class) {
+            if ($parent === Model::class) {
                 break;
             }
             $permittedClasses[] = $parent;

--- a/src/Support/Generators/RelationPropertyGenerator.php
+++ b/src/Support/Generators/RelationPropertyGenerator.php
@@ -33,8 +33,16 @@ class RelationPropertyGenerator implements IPropertyGenerator
         $withProperty->setAccessible(true);
         $withFields = $withProperty->getValue($model);
 
+        $permittedClasses = [get_class($model)];
+        foreach(class_parents($model) as $parent) {
+            if ($parent == Model::class) {
+                break;
+            }
+            $permittedClasses[] = $parent;
+        }
+
         foreach ($reflectionClass->getMethods() as $method) {
-            if ($method->class === get_class($model)) {
+            if (in_array($method->class, $permittedClasses)) {
                 // FIXME: if there only is docblock available, make sure it works for unqualified names aswell
                 $returnType = $this->getReturnType($method);
 


### PR DESCRIPTION
If the model has other intermediate classes between it and `Model`, then allow relations defined in those to be generated as well.

Not confident on the logic for building `$permittedClasses`, as I could have flipped the logic and instead done `if (Str::startsWith($parent, 'App'))`, but I saw the `TODO` further down the file about packagised models so thought to make it more open.