### PR TITLE
Allow model return types for attributes

### DIFF
--- a/src/Support/Generators/AttributePropertyGenerator.php
+++ b/src/Support/Generators/AttributePropertyGenerator.php
@@ -51,6 +51,11 @@ class AttributePropertyGenerator implements IPropertyGenerator
      */
     public function formatPhpReturnType(string $returnType): string
     {
+        $relatedClassSegments = explode('\\', $returnType);
+        if ($relatedClassSegments[0] === 'App') {
+            return end($relatedClassSegments);
+        }
+
         switch ($returnType) {
             case 'string':
                 return 'string';


### PR DESCRIPTION
This lets attributes that return another model to have appropriate TS types generated. This is useful for when there is a related model (possibly with additional logic around it) that is more complex than a simple relation would be used for.