### PR TITLE
fix: implicitly declare filename as null

### DIFF
--- a/src/Console/Commands/GenerateTypesCommand.php
+++ b/src/Console/Commands/GenerateTypesCommand.php
@@ -281,10 +281,10 @@ class GenerateTypesCommand extends Command
      *
      * @param  string      $modelPath
      * @param  string      $content
-     * @param  null|string $filename
+     * @param  ?string     $filename
      * @return void
      */
-    private function writeToTsFile(string $modelPath, string $content, string $filename = null): void
+    private function writeToTsFile(string $modelPath, string $content, ?string $filename = null): void
     {
         $sanitizedString = str_replace(unify_path($this->modelDir) . '/', '', unify_path($modelPath));
         $locationSegments = explode('/', $sanitizedString);


### PR DESCRIPTION
I got the following error when trying to use this package in my laravel 11 project:

```json
{
  "message":"Scrumble\\TypeGenerator\\Console\\Commands\\GenerateTypesCommand::writeToTsFile(): Implicitly marking parameter $filename as nullable is deprecated, the explicit nullable type must be used instead in /<project-path>/vendor/scrumble-nl/laravel-model-ts-type/src/Console/Commands/GenerateTypesCommand.php on line 287",
  "context":{
    "__pail":{
      "origin":{
        "type":"console",
        "command":null,
        "trace":null
      }
    }
  },
  "level":300,
  "level_name":"WARNING",
  "channel":"pail",
  "datetime":"2025-02-02T21:06:12.010531+01:00",
  "extra":{}
}
```

This should be fixed with the implicit declaration now.