### PR TITLE
Add `boolean` to `BOOL_TYPES`

### DIFF
--- a/src/Support/Generators/MysqlConsts.php
+++ b/src/Support/Generators/MysqlConsts.php
@@ -19,7 +19,7 @@ class MysqlConsts
     /**
      * @var array<int, string>
      */
-    public const BOOL_TYPES = ['tinyint'];
+    public const BOOL_TYPES = ['tinyint', 'boolean'];
 
     /**
      * @var array<int, string>


### PR DESCRIPTION
PostgreSQL has a boolean type which isn't properly processed during type generation. This merge resolves that.