### PR TITLE
fix: Replace array_first with Arr::first for consistency

### DIFF
--- a/src/Support/Generators/RelationPropertyGenerator.php
+++ b/src/Support/Generators/RelationPropertyGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Scrumble\TypeGenerator\Support\Generators;
 
+use Illuminate\Support\Arr;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;
@@ -50,7 +51,7 @@ class RelationPropertyGenerator implements IPropertyGenerator
                     continue;
                 }
 
-                $relationReturn = array_first($returnType, fn ($type) => str_contains($type, self::RELATION_TYPE));
+                $relationReturn = Arr::first($returnType, fn ($type) => str_contains($type, self::RELATION_TYPE));
 
                 if ($relationReturn) {
                     $methodName = $method->getName();


### PR DESCRIPTION
In Laravel 12, Symfony has a php8.5 poly fill for array_first which prevents Laravel's default helper function from getting set for it. Symfony's implementation doesn't support the callback function and will break the model if it has a function which requires parameters. Directly calling Laravel's Arr::first function solves this issue