### PR TITLE
Add PHP 8.5 to the CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.4, 8.3, 8.2, 8.1]
+        php: [8.5, 8.4, 8.3, 8.2, 8.1]
         laravel: ['^13.0', '^12.0', ^10.0, ^11.0]
         dependency-version: [prefer-stable]
         include:
@@ -31,6 +31,10 @@ jobs:
             php: 8.1
           - laravel: '^13.0'
             php: 8.2
+          - laravel: ^10.0
+            php: 8.5
+          - laravel: ^11.0
+            php: 8.5
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/src/Support/Mutators/CastsPropertyMutator.php
+++ b/src/Support/Mutators/CastsPropertyMutator.php
@@ -49,7 +49,6 @@ class CastsPropertyMutator implements IPropertyMutator
     {
         $reflectionClass = new ReflectionClass($model);
         $castsProperty = $reflectionClass->getProperty('casts');
-        $castsProperty->setAccessible(true);
 
         return $castsProperty->getValue($model);
     }


### PR DESCRIPTION
- composer already declares Laravel 13 support (merged in #62); this adds PHP 8.5 to the GitHub Actions matrix (excludes Laravel 10/11 on 8.5).
- Remove a deprecated no-op `ReflectionProperty::setAccessible(true)` (deprecated in PHP 8.5, no-op since 8.1).
- 19 tests pass on PHP 8.5 + Laravel 13.14.