### PR TITLE
Run php-cs-fixer and phpstan in CI (L13 / PHP 8.4)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,3 +56,27 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/phpunit
+
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint & Static Analysis
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          extensions: curl, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, iconv
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction
+
+      - name: Check code style
+        run: composer lint
+
+      - name: Static analysis
+        run: composer analyse

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,10 @@
     "scripts": {
         "post-autoload-dump": [
             "@php ./vendor/bin/testbench package:discover --ansi"
-        ]
+        ],
+        "test": "phpunit",
+        "lint": "php-cs-fixer fix --dry-run --diff --allow-risky=yes",
+        "format": "php-cs-fixer fix --allow-risky=yes",
+        "analyse": "phpstan analyse --memory-limit=1G"
     }
 }

--- a/src/Console/Commands/GenerateTypesCommand.php
+++ b/src/Console/Commands/GenerateTypesCommand.php
@@ -6,8 +6,9 @@ namespace Scrumble\TypeGenerator\Console\Commands;
 
 use Exception;
 use ReflectionClass;
+use DirectoryIterator;
 use ReflectionException;
-use Illuminate\Support\Str;
+use UnexpectedValueException;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Database\Eloquent\Model;
@@ -54,7 +55,7 @@ class GenerateTypesCommand extends Command
     /**
      * @var bool|string
      */
-    private string|bool $namespace;
+    private bool|string $namespace;
 
     /**
      * @var bool
@@ -64,7 +65,7 @@ class GenerateTypesCommand extends Command
     /**
      * @var null|string
      */
-    private string|null $model;
+    private ?string $model;
 
     /**
      * @var string
@@ -125,7 +126,8 @@ class GenerateTypesCommand extends Command
         $this->outputDir = $this->option('outputDir') ?? config('laravel-model-ts-type.output_dir');
         $this->useKebabCase = !($this->option('noKebabCase') ?: config('laravel-model-ts-type.no_kebab_case'));
         $this->indentation = $this->formatIndentation();
-        $this->model = $this->option('model') ?? null;
+        $model = $this->option('model');
+        $this->model = is_string($model) ? $model : null;
 
         $this->getModels($this->modelDir);
 
@@ -171,9 +173,9 @@ class GenerateTypesCommand extends Command
     /**
      * Format the contents for the TypeScript file.
      *
-     * @param  string      $className
-     * @param  array<array-key, array<array-key, mixed>>       $propertyDefinition
-     * @param  null|string $namespace
+     * @param  string                                    $className
+     * @param  array<array-key, array<array-key, mixed>> $propertyDefinition
+     * @param  null|string                               $namespace
      * @return string
      */
     private function formatContents(string $className, array $propertyDefinition, ?string $namespace): string
@@ -210,14 +212,14 @@ class GenerateTypesCommand extends Command
     private function getModels(string $directoryPath): void
     {
         try {
-            foreach (new \DirectoryIterator($directoryPath) as $file) {
+            foreach (new DirectoryIterator($directoryPath) as $file) {
                 if ($file->isDir() && !$file->isDot()) {
                     $this->getModels($file->getPathname());
                 } elseif (!$file->isDot()) {
                     $this->modelHits[] = $file->getPathname();
                 }
             }
-        } catch (\UnexpectedValueException $exception) {
+        } catch (UnexpectedValueException $exception) {
             throw new InvalidPathException('Could not find the given directory');
         }
     }
@@ -225,7 +227,7 @@ class GenerateTypesCommand extends Command
     /**
      * Create all different property definitions.
      *
-     * @param  Model               $model
+     * @param  Model                                     $model
      * @throws Exception
      * @throws ReflectionException
      * @return array<array-key, array<array-key, mixed>>
@@ -245,7 +247,7 @@ class GenerateTypesCommand extends Command
     }
 
     /**
-     * @param  string $modelPath
+     * @param  string             $modelPath
      * @return array<int, string>
      */
     private function getLocationSegments(string $modelPath): array
@@ -279,9 +281,9 @@ class GenerateTypesCommand extends Command
     /**
      * Write the given model to a TypeScript file.
      *
-     * @param  string      $modelPath
-     * @param  string      $content
-     * @param  ?string     $filename
+     * @param  string  $modelPath
+     * @param  string  $content
+     * @param  ?string $filename
      * @return void
      */
     private function writeToTsFile(string $modelPath, string $content, ?string $filename = null): void
@@ -307,6 +309,6 @@ class GenerateTypesCommand extends Command
     {
         $indentationSize = $this->option('indentationSpaces') ?? config('laravel-model-ts-type.indentation_spaces') ?? 4;
 
-        return str_pad(' ', (int)$indentationSize);
+        return str_pad(' ', (int) $indentationSize);
     }
 }

--- a/src/Exceptions/InvalidPathException.php
+++ b/src/Exceptions/InvalidPathException.php
@@ -6,6 +6,4 @@ namespace Scrumble\TypeGenerator\Exceptions;
 
 use Exception;
 
-class InvalidPathException extends Exception
-{
-}
+class InvalidPathException extends Exception {}

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -11,13 +11,13 @@ if (!function_exists('unify_path')) {
      */
     function unify_path(string $path): string
     {
-        return preg_replace('/\\\\/', '/', $path) ?? '';
+        return preg_replace('/\\\/', '/', $path) ?? '';
     }
 }
 
 if (!function_exists('extractEnumName')) {
     /**
-     * @param  class-string<UnitEnum>              $fullyQualifiedName
+     * @param  class-string<UnitEnum> $fullyQualifiedName
      * @throws ReflectionException
      * @return string
      */
@@ -29,7 +29,7 @@ if (!function_exists('extractEnumName')) {
 
 if (!function_exists('extractEnumShortName')) {
     /**
-     * @param  class-string<UnitEnum>              $fullyQualifiedName
+     * @param  class-string<UnitEnum> $fullyQualifiedName
      * @throws ReflectionException
      * @return string
      */

--- a/src/Interfaces/IPropertyGenerator.php
+++ b/src/Interfaces/IPropertyGenerator.php
@@ -12,7 +12,7 @@ interface IPropertyGenerator
     /**
      * Get the property definition for the given model.
      *
-     * @param  Model     $model
+     * @param  Model                                     $model
      * @throws Exception
      * @return array<array-key, array<array-key, mixed>>
      */

--- a/src/Interfaces/IPropertyMutator.php
+++ b/src/Interfaces/IPropertyMutator.php
@@ -12,8 +12,8 @@ interface IPropertyMutator
     /**
      * Mutate the given property definition for the given model.
      *
-     * @param  Model                $model
-     * @param  array<array-key, array<array-key, mixed>>                $propertyDefinition
+     * @param  Model                                     $model
+     * @param  array<array-key, array<array-key, mixed>> $propertyDefinition
      * @throws ReflectionException
      */
     public function mutate(Model $model, array &$propertyDefinition): void;

--- a/src/Support/Generators/AttributePropertyGenerator.php
+++ b/src/Support/Generators/AttributePropertyGenerator.php
@@ -95,11 +95,11 @@ class AttributePropertyGenerator implements IPropertyGenerator
     private function getPropertyType(ReflectionMethod $method): string
     {
         if (null !== ($returnType = $method->getReturnType())) {
-            if($returnType instanceof ReflectionUnionType) {
+            if ($returnType instanceof ReflectionUnionType) {
                 return collect($returnType->getTypes())
-                    ->map(function($returnType) {
-                        /** @phpstan-ignore-next-line */
-                        return $this->formatPhpReturnType($returnType->getName()) ;
+                    ->map(function ($returnType) {
+                        // @phpstan-ignore-next-line
+                        return $this->formatPhpReturnType($returnType->getName());
                     })
                     ->join(' | ') . ($returnType->allowsNull() ? ' | null' : '');
             }

--- a/src/Support/Generators/DatabasePropertyGenerator.php
+++ b/src/Support/Generators/DatabasePropertyGenerator.php
@@ -82,7 +82,7 @@ class DatabasePropertyGenerator implements IPropertyGenerator
     /**
      * Format the given database field.
      *
-     * @param  array<string, mixed> $field
+     * @param  array<string, mixed>  $field
      * @return array<string, string>
      */
     public function formatDatabaseType(array $field): array
@@ -111,9 +111,9 @@ class DatabasePropertyGenerator implements IPropertyGenerator
 
         return [
             'operator' => ':',
-            'value' => $type .
-                ($field['isNullable'] ? ' | null' : '') .
-                ('any' === $type ? ' // NOT FOUND' : ''),
+            'value' => $type
+                . ($field['isNullable'] ? ' | null' : '')
+                . ('any' === $type ? ' // NOT FOUND' : ''),
         ];
     }
 }

--- a/src/Support/Generators/RelationPropertyGenerator.php
+++ b/src/Support/Generators/RelationPropertyGenerator.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Scrumble\TypeGenerator\Support\Generators;
 
-use Illuminate\Support\Arr;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionUnionType;
+use Illuminate\Support\Arr;
 use ReflectionIntersectionType;
 use Illuminate\Database\Eloquent\Model;
 use Scrumble\TypeGenerator\Interfaces\IPropertyGenerator;
@@ -35,7 +35,7 @@ class RelationPropertyGenerator implements IPropertyGenerator
         $withFields = $withProperty->getValue($model);
 
         $permittedClasses = [get_class($model)];
-        foreach(class_parents($model) as $parent) {
+        foreach (class_parents($model) as $parent) {
             if ($parent === Model::class) {
                 break;
             }
@@ -76,16 +76,32 @@ class RelationPropertyGenerator implements IPropertyGenerator
     }
 
     /**
+     * Format the value used for the types.
+     *
+     * @param  string $relatedClass
+     * @param  string $returnType
+     * @return string
+     */
+    public function formatValue(string $relatedClass, string $returnType): string
+    {
+        if (str_ends_with($returnType, 'MorphTo')) {
+            $relatedClass = 'any';
+        }
+
+        return $relatedClass . (str_contains($returnType, 'Many') ? '[]' : '') . ' | null';
+    }
+
+    /**
      * Get return type based on typing or doc block.
      *
-     * @param ReflectionMethod $method
+     * @param  ReflectionMethod        $method
      * @return null|array<int, string>
      */
     private function getReturnType(ReflectionMethod $method): ?array
     {
         if (null !== ($returnType = $method->getReturnType())) {
             if (in_array($returnType::class, self::REFLECTION_RETURN_TYPES)) {
-                /** @phpstan-ignore-next-line: if it gets here the type is definitely correct */
+                // @phpstan-ignore-next-line: if it gets here the type is definitely correct
                 return $this->parseReflectionReturnType($returnType);
             }
         }
@@ -107,10 +123,10 @@ class RelationPropertyGenerator implements IPropertyGenerator
     }
 
     /**
-     * @param ReflectionNamedType|ReflectionUnionType|ReflectionIntersectionType $returnType
+     * @param  ReflectionIntersectionType|ReflectionNamedType|ReflectionUnionType $returnType
      * @return null|array<int, string>
      */
-    private function parseReflectionReturnType(ReflectionNamedType|ReflectionUnionType|ReflectionIntersectionType $returnType): ?array
+    private function parseReflectionReturnType(ReflectionIntersectionType|ReflectionNamedType|ReflectionUnionType $returnType): ?array
     {
         if ($returnType instanceof ReflectionIntersectionType) {
             return null;
@@ -127,21 +143,5 @@ class RelationPropertyGenerator implements IPropertyGenerator
         }
 
         return [$returnType->getName()];
-    }
-
-    /**
-     * Format the value used for the types.
-     *
-     * @param string $relatedClass
-     * @param string $returnType
-     * @return string
-     */
-    public function formatValue(string $relatedClass, string $returnType): string
-    {
-        if (str_ends_with($returnType, 'MorphTo')) {
-            $relatedClass = 'any';
-        }
-
-        return $relatedClass . (str_contains($returnType, 'Many') ? '[]' : '') . ' | null';
     }
 }

--- a/src/Support/Mutators/CastsPropertyMutator.php
+++ b/src/Support/Mutators/CastsPropertyMutator.php
@@ -42,7 +42,7 @@ class CastsPropertyMutator implements IPropertyMutator
     }
 
     /**
-     * @param Model $model
+     * @param  Model                   $model
      * @return array<array-key, mixed>
      */
     private function getCastValues(Model $model): array

--- a/src/Support/Mutators/HiddenPropertyMutator.php
+++ b/src/Support/Mutators/HiddenPropertyMutator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Scrumble\TypeGenerator\Support\Mutators;
 
+use ReflectionClass;
 use Illuminate\Database\Eloquent\Model;
 use Scrumble\TypeGenerator\Interfaces\IPropertyMutator;
 
@@ -14,7 +15,7 @@ class HiddenPropertyMutator implements IPropertyMutator
      */
     public function mutate(Model $model, array &$propertyDefinition): void
     {
-        $reflectionClass = new \ReflectionClass($model);
+        $reflectionClass = new ReflectionClass($model);
         $hiddenProperty = $reflectionClass->getProperty('hidden');
         $hiddenProperty->setAccessible(true);
         $hiddenFields = $hiddenProperty->getValue($model);

--- a/src/Support/TypescriptFormatters/EnumFormatter.php
+++ b/src/Support/TypescriptFormatters/EnumFormatter.php
@@ -7,8 +7,6 @@ namespace Scrumble\TypeGenerator\Support\TypescriptFormatters;
 use UnitEnum;
 use ReflectionEnum;
 use ReflectionException;
-use ReflectionEnumPureCase;
-use ReflectionEnumBackedCase;
 
 class EnumFormatter
 {
@@ -23,7 +21,7 @@ class EnumFormatter
     private ReflectionEnum $reflectionEnum;
 
     /**
-     * @param  class-string<UnitEnum>              $fullyQualifiedName
+     * @param  class-string<UnitEnum> $fullyQualifiedName
      * @throws ReflectionException
      */
     public function __construct(string $fullyQualifiedName)

--- a/tests/Feature/CastFunctionTest.php
+++ b/tests/Feature/CastFunctionTest.php
@@ -31,7 +31,7 @@ class CastFunctionTest extends TestCase
         }
 
         $this->deleteFiles = false;
-        $modelPath = addslashes('--model=Tests\\Models\\CastFunction');
+        $modelPath = addslashes('--model=Tests\Models\CastFunction');
 
         $this->runCommand($modelPath);
 

--- a/tests/Feature/EnumTest.php
+++ b/tests/Feature/EnumTest.php
@@ -48,7 +48,7 @@ class EnumTest extends TestCase
         $this->runCommand('', __DIR__ . '/../Models/Enums');
 
         $content = File::get(__DIR__ . '/../Output/another-enum.d.ts');
-        $expected = File::get(__DIR__.'/Expected/another-enum.d.ts');
+        $expected = File::get(__DIR__ . '/Expected/another-enum.d.ts');
 
         $this->assertEquals($expected, $content);
 
@@ -59,7 +59,7 @@ class EnumTest extends TestCase
     public function models_reference_enum()
     {
         $this->modelList = ['bar'];
-        $this->runCommand('--model=Tests\\\\Models\\\\Bar');
+        $this->runCommand('--model=Tests\\\Models\\\Bar');
 
         $content = File::get(__DIR__ . '/../Output/bar.d.ts');
         $expected = File::get(__DIR__ . '/Expected/bar.d.ts');

--- a/tests/Feature/GeneratesTypesCommandTest.php
+++ b/tests/Feature/GeneratesTypesCommandTest.php
@@ -21,7 +21,8 @@ class GeneratesTypesCommandTest extends TestCase
      * @test
      * @throws Exception
      */
-    public function command_absolute_path() {
+    public function command_absolute_path()
+    {
         $this->runCommand();
     }
 
@@ -32,7 +33,7 @@ class GeneratesTypesCommandTest extends TestCase
      */
     public function command_option_namespace(): void
     {
-        $this->runCommand('--namespace=Tests\\Models');
+        $this->runCommand('--namespace=Tests\Models');
     }
 
     /**
@@ -53,7 +54,7 @@ class GeneratesTypesCommandTest extends TestCase
     public function command_option_model(): void
     {
         $this->modelList = ['foo'];
-        $modelPath = addslashes('--model=Tests\\Models\\Foo');
+        $modelPath = addslashes('--model=Tests\Models\Foo');
 
         $this->runCommand($modelPath);
     }

--- a/tests/Models/Bar.php
+++ b/tests/Models/Bar.php
@@ -10,14 +10,14 @@ use Illuminate\Database\Eloquent\Model;
 class Bar extends Model
 {
     /**
-     * @var string
-     */
-    protected $table = 'bar';
-
-    /**
      * @var bool
      */
     public $timestamps = false;
+
+    /**
+     * @var string
+     */
+    protected $table = 'bar';
 
     /**
      * @var array
@@ -30,15 +30,15 @@ class Bar extends Model
     ];
 
     /**
-     * @return string|int
+     * @return int|string
      */
-    public function unionReturn(): string|int
+    public function unionReturn(): int|string
     {
         return '';
     }
 
     /**
-     * @return string|int
+     * @return int|string
      */
     public function unionDocReturn()
     {

--- a/tests/Models/Enums/AnotherEnum.php
+++ b/tests/Models/Enums/AnotherEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Models\Enums;
 
 enum AnotherEnum: int

--- a/tests/Models/Enums/ETestEnum.php
+++ b/tests/Models/Enums/ETestEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Models\Enums;
 
 enum ETestEnum: string

--- a/tests/Models/Foo.php
+++ b/tests/Models/Foo.php
@@ -8,9 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class Foo extends Model
 {
-    protected $table = 'foo';
-
     public $timestamps = false;
+    protected $table = 'foo';
 
     protected $casts = [
         'total' => 'int',

--- a/tests/Models/TestTrait.php
+++ b/tests/Models/TestTrait.php
@@ -1,7 +1,11 @@
 <?php
 
-trait TestTrait {
-    public function foo() {
+declare(strict_types=1);
+
+trait TestTrait
+{
+    public function foo()
+    {
         dd('test');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,7 +33,7 @@ class TestCase extends Orchestra
     }
 
     /**
-     * @param $app
+     * @param           $app
      * @return string[]
      */
     protected function getPackageProviders($app): array

--- a/tests/Unit/FormatNamespaceTest.php
+++ b/tests/Unit/FormatNamespaceTest.php
@@ -23,7 +23,7 @@ class FormatNamespaceTest extends TestCase
         $this->assertFileExists($modelFilePath);
 
         $namespace = FormatNamespace::get($modelFilePath);
-        $this->assertEquals('Tests\\Models\\Bar', $namespace);
+        $this->assertEquals('Tests\Models\Bar', $namespace);
     }
 
     /**
@@ -33,7 +33,7 @@ class FormatNamespaceTest extends TestCase
      */
     public function weird_path()
     {
-        $modelPath = __DIR__.'/../Unit/Support/../../Models/Bar.php';
+        $modelPath = __DIR__ . '/../Unit/Support/../../Models/Bar.php';
         $modelRealPath = realpath($modelPath);
 
         if (!$modelRealPath) {
@@ -41,6 +41,6 @@ class FormatNamespaceTest extends TestCase
         }
 
         $namespace = FormatNamespace::get($modelPath);
-        $this->assertEquals('Tests\\Models\\Bar', $namespace);
+        $this->assertEquals('Tests\Models\Bar', $namespace);
     }
 }

--- a/tests/Unit/MorphRelationTest.php
+++ b/tests/Unit/MorphRelationTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
-use Illuminate\Database\Eloquent\Relations\MorphMany;
-use Illuminate\Database\Eloquent\Relations\MorphOne;
-use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Scrumble\TypeGenerator\Support\Generators\RelationPropertyGenerator;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Scrumble\TypeGenerator\Support\Generators\RelationPropertyGenerator;
 
 /**
  * @internal

--- a/tests/Unit/Support/Mutators/CastsPropertyMutatorTest.php
+++ b/tests/Unit/Support/Mutators/CastsPropertyMutatorTest.php
@@ -22,9 +22,9 @@ class CastsPropertyMutatorTest extends TestCase
         $command->expects($this->exactly(3))
             ->method('warn')
             ->willReturnOnConsecutiveCalls(
-                ['Skipped property: Undefined property "yesterday" found in casts of model Tests\\Models\\Bar.'],
-                ['Skipped property: Undefined property "test" found in casts of model Tests\\Models\\Bar.'],
-                ['Skipped property: Undefined property "my_list" found in casts of model Tests\\Models\\Foo.']
+                ['Skipped property: Undefined property "yesterday" found in casts of model Tests\Models\Bar.'],
+                ['Skipped property: Undefined property "test" found in casts of model Tests\Models\Bar.'],
+                ['Skipped property: Undefined property "my_list" found in casts of model Tests\Models\Foo.']
             );
 
         $mutator = new CastsPropertyMutator($command);


### PR DESCRIPTION
## What

Laravel 13 / testbench 11 / PHP 8.4 support was already merged (#62, #63). The remaining gap was CI: php-cs-fixer and phpstan (level 8) were configured but never run. This wires them in and makes the codebase pass.

- Add a `Lint & Static Analysis` job to the GitHub Actions workflow (PHP 8.4) running php-cs-fixer + phpstan.
- Add composer scripts: `test`, `lint`, `format`, `analyse`.
- Fix a phpstan type error in `GenerateTypesCommand` — narrow `option('model')`'s widened return type with an `is_string` guard.
- Apply php-cs-fixer formatting across `src` and `tests` (pre-existing violations). The one risky change (a regex-escape normalization in `helpers.php`) was verified to produce identical output before applying.

## Verified locally

- `composer lint` → 0 issues · `composer analyse` → no errors · `composer test` → 19/19 pass
- Resolves Laravel 13.18.0 + testbench 11.1.0; matrix also exercises PHP 8.4 + L13.

Pulse: 17372. PHP floor kept at `^8.1` (still supports L10/L11). Release tag handled separately.

— 🤖 Claude Opus 4.8